### PR TITLE
add enable option to wireguard vpn subservice

### DIFF
--- a/module/vpn.nix
+++ b/module/vpn.nix
@@ -11,6 +11,8 @@ let
 
 in {
   options.bitmagnet.vpn = {
+    enable = mkEnableOption "Bitmagnet VPN service";
+
     name = mkOption {
       type = types.enum (attrNames cfg.vpn.peers);
       default = config.networking.hostName;
@@ -104,7 +106,7 @@ in {
     };
   };
 
-  config = mkIf (cfg.enable) {
+  config = mkIf (cfg.vpn.enable) {
     systemd.network = {
       netdevs."50-bitmagnet" = {
         netdevConfig = {

--- a/readme.md
+++ b/readme.md
@@ -1,25 +1,25 @@
-# NixOS module for bitmagnet.io
-This is a [NixOS](https://nixos.org) module for a distributed [bitmagnet](https://bitmagnet.io) setup.
-It provides a full-mesh VPN network using [wireguard](https://www.wireguard.com) allowing for multiple crawler to work together.
+# NixOS module for Bitmagnet.io
+This is a [NixOS](https://nixos.org) module for a distributed [Bitmagnet](https://bitmagnet.io) setup.
+It provides an optional full-mesh VPN network using [wireguard](https://www.wireguard.com) allowing for multiple crawlers to work together.
 
 ## Usage
 Import `./module/` in you config or use the `nixosModules.bitmagnet` flake output.
 See [`example.nix`](./example.nix) for a usage example.
 
 ## Contributing
-We welcome contributions from the community to help improve Photonic.
+We welcome contributions from the community to help improve this Bitmagnet NixOS module.
 Whether you're a developer, designer, or enthusiast, there are many ways to get involved:
 
-* **Bug Reports:** Report any issues or bugs you encounter while using Photonic.
-* **Feature Requests:** Suggest new features or enhancements to make Photonic even more powerful.
+* **Bug Reports:** Report any issues or bugs you encounter while using this Bitmagnet NixOS module.
+* **Feature Requests:** Suggest new features or enhancements to make this Bitmagnet NixOS module even more powerful.
 * **Pull Requests:** Submit pull requests to address bugs, implement new features, or improve documentation.
 
 ## License
-Photonic is licensed under the MIT License, which means you are free to use, modify, and distribute the software for both commercial and non-commercial purposes. See the [LICENSE](./LICENSE) file for more details.
+this Bitmagnet NixOS module is licensed under the MIT License, which means you are free to use, modify, and distribute the software for both commercial and non-commercial purposes. See the [LICENSE](./LICENSE) file for more details.
 
 ## Support
-If you have any questions, concerns, or feedback about Photonic, please [contact us](mailto:fooker@lab.sh) or open an issue on the project's GitHub repository.
+If you have any questions, concerns, or feedback about this Bitmagnet NixOS module, please [contact us](mailto:fooker@lab.sh) or open an issue on the project's GitHub repository.
 
 ## Acknowledgements
-We would like to thank all contributors and supporters who have helped make Photonic possible. Your contributions and feedback are greatly appreciated!
+We would like to thank all contributors and supporters who have helped make this Bitmagnet NixOS module possible. Your contributions and feedback are greatly appreciated!
 


### PR DESCRIPTION
I left this style in place, but I think it might benefit from an option to disable the vpn subservice.
```let
  cfg = config.bitmagnet;
```
